### PR TITLE
⬆️ chore(deps): bump urllib3 from 2.5.0 to 2.6.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "requests~=2.32.5",
     "soupsieve~=2.8",
     "typing_extensions~=4.15.0",
-    "urllib3>=2.5,<2.7",
+    "urllib3~=2.6.3",
     "tomli~=2.0.1; python_version < '3.11'"
 ]
 


### PR DESCRIPTION
Resolve known security vulnerabilities in urllib3:
- Improper highly compressed data handling (GHSA-2xpw-w6gg-jr37)
- Decompression bomb safeguards bypass (GHSA-38jv-5279-wg99)
- Unbounded links in decompression chain (GHSA-gm62-xv2j-4w53)