### PR TITLE
🔒 fix(security): prevent path traversal in output filenames

### DIFF
--- a/src/instapaper_scraper/output.py
+++ b/src/instapaper_scraper/output.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import tempfile
 from typing import List, Dict, Any, TYPE_CHECKING
 
 from .constants import (
@@ -154,6 +155,29 @@ def save_to_sqlite(
     logging.info(LOG_SAVED_ARTICLES.format(count=len(data), filename=db_name))
 
 
+def _validate_output_path(filename: str) -> None:
+    """
+    Validates that the output path is within a set of safe base directories
+    to prevent path traversal attacks.
+    """
+    # Get the absolute path of the intended file, resolving any '..'
+    file_path = os.path.abspath(filename)
+
+    # Define safe base directories for cross-platform compatibility.
+    # Using a set for efficient checking and to avoid duplicates.
+    safe_dirs = {
+        os.path.abspath(os.getcwd()),  # Current working directory
+        os.path.abspath(os.path.expanduser("~")),  # User's home directory
+        os.path.abspath(tempfile.gettempdir()),  # System's temporary directory
+    }
+
+    # Check if the file path is within any of the safe base directories.
+    if not any(os.path.commonpath([base, file_path]) == base for base in safe_dirs):
+        raise ValueError(
+            f"Path traversal attempt detected. Output path '{filename}' is outside allowed directories (current working directory, home, or temp)."
+        )
+
+
 def _correct_ext(filename: str, format: str) -> str:
     """Corrects the filename extension based on the specified format."""
     extension_map = {
@@ -180,6 +204,8 @@ def save_articles(
     if not data:
         logging.info(LOG_NO_ARTICLES)
         return
+
+    _validate_output_path(filename)
 
     filename = _correct_ext(filename, format)
 

--- a/src/instapaper_scraper/output.py
+++ b/src/instapaper_scraper/output.py
@@ -160,19 +160,28 @@ def _validate_output_path(filename: str) -> None:
     Validates that the output path is within a set of safe base directories
     to prevent path traversal attacks.
     """
-    # Get the absolute path of the intended file, resolving any '..'
-    file_path = os.path.abspath(filename)
+    # Get the real path to resolve symlinks and '..'
+    file_path = os.path.realpath(filename)
 
-    # Define safe base directories for cross-platform compatibility.
-    # Using a set for efficient checking and to avoid duplicates.
-    safe_dirs = {
-        os.path.abspath(os.getcwd()),  # Current working directory
-        os.path.abspath(os.path.expanduser("~")),  # User's home directory
-        os.path.abspath(tempfile.gettempdir()),  # System's temporary directory
-    }
+    # Define safe base directories using realpath for consistent comparison.
+    safe_dirs = [
+        os.path.realpath(os.getcwd()),  # Current working directory
+        os.path.realpath(os.path.expanduser("~")),  # User's home directory
+        os.path.realpath(tempfile.gettempdir()),  # System's temporary directory
+    ]
 
-    # Check if the file path is within any of the safe base directories.
-    if not any(os.path.commonpath([base, file_path]) == base for base in safe_dirs):
+    is_safe = False
+    for base in safe_dirs:
+        try:
+            # Check if the file path is within the safe base directory.
+            if os.path.commonpath([base, file_path]) == base:
+                is_safe = True
+                break
+        except ValueError:
+            # On Windows, commonpath raises ValueError if paths are on different drives.
+            continue
+
+    if not is_safe:
         raise ValueError(
             f"Path traversal attempt detected. Output path '{filename}' is outside allowed directories (current working directory, home, or temp)."
         )

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import pytest
 import json
 import sqlite3
@@ -12,6 +14,7 @@ from instapaper_scraper.output import (
     save_to_json,
     save_to_sqlite,
     save_articles,
+    _validate_output_path,
     get_sqlite_create_table_sql,
     get_sqlite_insert_sql,
 )
@@ -366,3 +369,87 @@ def test_save_articles_unknown_format(sample_articles, output_dir, caplog):
         save_articles(sample_articles(), "unknown", str(output_file))
     assert "Unknown output format: unknown" in caplog.text
     assert not output_file.exists()
+
+
+class TestValidateOutputPath:
+    @pytest.fixture(autouse=True)
+    def setup_mock_paths(self, monkeypatch, tmp_path):
+        """
+        Mocks os.getcwd, os.path.expanduser, and tempfile.gettempdir
+        for each test in this class.
+        """
+        # Make cwd the tmp_path itself, so output_dir (tmp_path / "output") is within cwd
+        self._cwd = tmp_path
+        self._home_dir = tmp_path / "user_home_dir"
+        self._home_dir.mkdir()
+        self._temp_dir = tmp_path / "system_temp_dir"
+        self._temp_dir.mkdir()
+
+        monkeypatch.setattr(os, "getcwd", lambda: str(self._cwd))
+        # Mock os.path.expanduser to return the mocked home_dir only for "~"
+        original_expanduser = os.path.expanduser
+
+        def mock_expanduser(path):
+            if path == "~" or path.startswith("~/"):
+                # Handle paths like "~/Documents"
+                return (
+                    str(self._home_dir / path[2:])
+                    if path.startswith("~/")
+                    else str(self._home_dir)
+                )
+            return original_expanduser(path)
+
+        monkeypatch.setattr(os.path, "expanduser", mock_expanduser)
+
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(self._temp_dir))
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            "file.txt",
+            "subdir/file.txt",
+            "./file.txt",
+        ],
+    )
+    def test_valid_path_in_cwd(self, relative_path):
+        """Test a valid path within the current working directory."""
+        filename = str(self._cwd / relative_path)
+        _validate_output_path(filename)  # Should not raise an error
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            "file.txt",
+            "Documents/report.pdf",
+            "../user_home_dir/another_file.txt",  # Path that resolves within home dir
+        ],
+    )
+    def test_valid_path_in_home_dir(self, relative_path):
+        """Test a valid path within the user's home directory."""
+        filename = str(self._home_dir / relative_path)
+        _validate_output_path(filename)  # Should not raise an error
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            "temp_output.log",
+            "my_app/cache.tmp",
+            "../system_temp_dir/log.txt",  # Path that resolves within temp dir
+        ],
+    )
+    def test_valid_path_in_temp_dir(self, relative_path):
+        """Test a valid path within the system's temporary directory."""
+        filename = str(self._temp_dir / relative_path)
+        _validate_output_path(filename)  # Should not raise an error
+
+    @pytest.mark.parametrize(
+        "malicious_path",
+        [
+            "/absolute/path/outside/safe/pwned.txt",
+            "../../../../etc/passwd",  # Relative path that resolves outside safe dirs
+        ],
+    )
+    def test_invalid_path_outside_safe_dirs(self, malicious_path):
+        """Test paths that attempt to traverse outside allowed directories."""
+        with pytest.raises(ValueError, match="Path traversal attempt detected"):
+            _validate_output_path(malicious_path)


### PR DESCRIPTION
This PR addresses a path traversal vulnerability found in the output filename handling.

Key changes:
- Adds validation in `_validate_output_path` to prevent directory traversal attacks when specifying an output file.
- Introduces unit tests to verify that the path traversal prevention is working correctly.

Commits:
- `fix(security): add path traversal validation for output filenames`
- `test(output): add unit tests for _validate_output_path path traversal prevention`