### PR TITLE
🔒️ feat(api): validate folder_id and slug for URL-safe characters

### DIFF
--- a/src/instapaper_scraper/api.py
+++ b/src/instapaper_scraper/api.py
@@ -245,9 +245,9 @@ class InstapaperClient:
         # Allowed characters: alphanumeric, hyphen, underscore
         url_safe_pattern = re.compile(r"^[a-zA-Z0-9_-]+$")
 
-        if folder_id and not url_safe_pattern.match(folder_id):
+        if folder_id and not url_safe_pattern.match(str(folder_id)):
             raise ValueError(f"Invalid characters in folder_id: {folder_id}")
-        if slug and not url_safe_pattern.match(slug):
+        if slug and not url_safe_pattern.match(str(slug)):
             raise ValueError(f"Invalid characters in slug: {slug}")
 
         if folder_id in self.SPECIAL_FOLDERS:

--- a/src/instapaper_scraper/api.py
+++ b/src/instapaper_scraper/api.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import time
+import re
 from typing import List, Dict, Tuple, Optional, Any
 
 import requests
@@ -238,6 +239,16 @@ class InstapaperClient:
     ) -> str:
         """Constructs the URL for the given page, considering folder mode."""
         folder_id = folder_info.get("id") if folder_info else None
+        slug = folder_info.get("slug") if folder_info else None
+
+        # Validate folder_id and slug for URL-safe characters
+        # Allowed characters: alphanumeric, hyphen, underscore
+        url_safe_pattern = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+        if folder_id and not url_safe_pattern.match(folder_id):
+            raise ValueError(f"Invalid characters in folder_id: {folder_id}")
+        if slug and not url_safe_pattern.match(slug):
+            raise ValueError(f"Invalid characters in slug: {slug}")
 
         if folder_id in self.SPECIAL_FOLDERS:
             base_url = self.SPECIAL_FOLDERS[folder_id]

--- a/src/instapaper_scraper/api.py
+++ b/src/instapaper_scraper/api.py
@@ -53,6 +53,9 @@ class InstapaperClient:
         "archive": INSTAPAPER_ARCHIVE_URL,
     }
 
+    # URL validation
+    URL_SAFE_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+
     # HTTP status codes
     HTTP_TOO_MANY_REQUESTS = 429
     HTTP_SERVER_ERROR_START = 500
@@ -243,11 +246,9 @@ class InstapaperClient:
 
         # Validate folder_id and slug for URL-safe characters
         # Allowed characters: alphanumeric, hyphen, underscore
-        url_safe_pattern = re.compile(r"^[a-zA-Z0-9_-]+$")
-
-        if folder_id and not url_safe_pattern.match(str(folder_id)):
+        if folder_id and not self.URL_SAFE_PATTERN.match(str(folder_id)):
             raise ValueError(f"Invalid characters in folder_id: {folder_id}")
-        if slug and not url_safe_pattern.match(str(slug)):
+        if slug and not self.URL_SAFE_PATTERN.match(str(slug)):
             raise ValueError(f"Invalid characters in slug: {slug}")
 
         if folder_id in self.SPECIAL_FOLDERS:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,7 @@ import requests_mock
 import logging
 from unittest.mock import MagicMock, patch
 from bs4 import BeautifulSoup
+import re
 
 from instapaper_scraper.api import InstapaperClient
 from instapaper_scraper.exceptions import ScraperStructureChanged
@@ -365,6 +366,41 @@ def test_get_page_url(client, folder_info, expected_url_path):
     page = 1
     expected_url = f"{INSTAPAPER_BASE_URL}{expected_url_path}{page}"
     assert client._get_page_url(page, folder_info) == expected_url
+
+
+@pytest.mark.parametrize(
+    "invalid_folder_id",
+    [
+        "invalid id!",  # Contains space and exclamation mark
+        "invalid/id",  # Contains slash
+        "invalid?id",  # Contains question mark
+    ],
+)
+def test_get_page_url_invalid_folder_id(client, invalid_folder_id):
+    """Test _get_page_url raises ValueError for invalid folder_id."""
+    with pytest.raises(
+        ValueError,
+        match=f"Invalid characters in folder_id: {re.escape(invalid_folder_id)}",
+    ):
+        client._get_page_url(
+            page=1, folder_info={"id": invalid_folder_id, "slug": "any-slug"}
+        )
+
+
+@pytest.mark.parametrize(
+    "invalid_slug",
+    [
+        "invalid slug!",  # Contains space and exclamation mark
+        "invalid/slug",  # Contains slash
+        "invalid?slug",  # Contains question mark
+    ],
+)
+def test_get_page_url_invalid_slug(client, invalid_slug):
+    """Test _get_page_url raises ValueError for invalid slug."""
+    with pytest.raises(
+        ValueError, match=f"Invalid characters in slug: {re.escape(invalid_slug)}"
+    ):
+        client._get_page_url(page=1, folder_info={"id": "any-id", "slug": invalid_slug})
 
 
 def test_get_articles_connection_error_retries(client, session, monkeypatch, caplog):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -698,3 +698,8 @@ def test_get_articles_without_preview(client, session):
         assert len(articles) == 2
         assert "article_preview" not in articles[0]
         assert "article_preview" not in articles[1]
+
+
+def test_url_safe_pattern_is_compiled_regex():
+    """Test that URL_SAFE_PATTERN is a compiled regex object."""
+    assert isinstance(InstapaperClient.URL_SAFE_PATTERN, re.Pattern)


### PR DESCRIPTION
Add input validation in _get_page_url to ensure folder_id and slug only contain alphanumeric characters, hyphens, and underscores. Raises ValueError if invalid characters are detected.