### PR TITLE
🔧 chore(debug): add VS Code debug configurations and API debug helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,15 +179,6 @@ poetry.toml
 # LSP config files
 pyrightconfig.json
 
-### VisualStudioCode ###
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/debug_api.py
-!.vscode/extensions.json
-!.vscode/*.code-snippets
-
 # Local History for Visual Studio Code
 .history/
 

--- a/.gitignore
+++ b/.gitignore
@@ -184,6 +184,7 @@ pyrightconfig.json
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
+!.vscode/debug_api.py
 !.vscode/extensions.json
 !.vscode/*.code-snippets
 

--- a/.vscode/debug_api.py
+++ b/.vscode/debug_api.py
@@ -1,0 +1,96 @@
+"""Debug helper for InstapaperClient.
+
+Run via the 'Debug API' VS Code launch configuration to set breakpoints in
+api.py and step through the InstapaperClient methods (e.g. _fetch_form_key,
+get_articles, _parse_bookmarks, _wait_for_retry, etc.).
+
+This script uses requests_mock (a dev dependency) to mock the Instapaper API
+responses, so no real credentials or network calls are required.
+
+To debug a specific method:
+  1. Set a breakpoint in src/instapaper_scraper/api.py.
+  2. Select "Debug API" from the VS Code Run panel and press F5.
+  3. Step through the mocked call flow.
+"""
+import requests
+import requests_mock
+
+from instapaper_scraper.api import InstapaperClient
+from instapaper_scraper.constants import (
+    INSTAPAPER_BOOKMARKS_URL,
+    INSTAPAPER_USER_SESSION_URL,
+)
+
+
+def main() -> None:
+    """Entry point for debugging the InstapaperClient API."""
+    session = requests.Session()
+    client = InstapaperClient(session)
+
+    print("=== InstapaperClient Debug Helper ===")
+    print(f"  max_retries:    {client.max_retries}")
+    print(f"  backoff_factor: {client.backoff_factor}")
+    print(f"  form_key:       {client._form_key}")
+    print()
+
+    # ---- Mock API responses ----
+    mock_session_response = {
+        "user": {
+            "id": 12345,
+            "email": "test@example.com",
+            "username": "testuser",
+            "form_key": "debug_form_key_1234567890",
+            "folders": [],
+            "tags": [],
+        }
+    }
+
+    mock_bookmarks_response = {
+        "bookmarks": [
+            {
+                "id": 1,
+                "url": "http://example.com/1",
+                "title": "Debug Article 1",
+                "description": "A preview of article 1.",
+                "author": "Author 1",
+                "time": 1785482560,
+                "site_name": "Example",
+                "liked": False,
+                "is_archived": False,
+                "tags": ["tag1"],
+                "notes": [],
+            },
+            {
+                "id": 2,
+                "url": "http://example.com/2",
+                "title": "Debug Article 2",
+                "description": "",
+            },
+        ],
+        "page": 1,
+        "has_more": False,
+    }
+
+    # ---- Exercise the client ----
+    with requests_mock.Mocker() as m:
+        m.get(INSTAPAPER_USER_SESSION_URL, json=mock_session_response)
+        m.get(INSTAPAPER_BOOKMARKS_URL, json=mock_bookmarks_response)
+
+        articles, has_more = client.get_articles(
+            page=1, add_article_preview=True
+        )
+
+        print(f"Fetched {len(articles)} articles. has_more: {has_more}")
+        print()
+        for article in articles:
+            print(f"  [{article['id']}] {article['title']}")
+            print(f"    URL: {article['url']}")
+            if "article_preview" in article:
+                print(f"    Preview: {article['article_preview']}")
+            print()
+
+    print("=== Debug helper finished ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,7 @@
             "module": "instapaper_scraper.cli",
             "console": "integratedTerminal",
             "justMyCode": false,
+            "cwd": "${workspaceFolder}",
             "env": {
                 "PYTHONPATH": "${workspaceFolder}/src"
             }
@@ -19,6 +20,7 @@
             "module": "instapaper_scraper.cli",
             "console": "integratedTerminal",
             "justMyCode": false,
+            "cwd": "${workspaceFolder}",
             "args": ["--version"],
             "env": {
                 "PYTHONPATH": "${workspaceFolder}/src"
@@ -31,6 +33,7 @@
             "program": "${workspaceFolder}/scripts/debug_api.py",
             "console": "integratedTerminal",
             "justMyCode": false,
+            "cwd": "${workspaceFolder}",
             "env": {
                 "PYTHONPATH": "${workspaceFolder}/src"
             }
@@ -42,6 +45,7 @@
             "module": "pytest",
             "console": "integratedTerminal",
             "justMyCode": false,
+            "cwd": "${workspaceFolder}",
             "args": [
                 "tests/test_api.py",
                 "-v",
@@ -59,6 +63,7 @@
             "module": "pytest",
             "console": "integratedTerminal",
             "justMyCode": false,
+            "cwd": "${workspaceFolder}",
             "args": [
                 "tests/test_cli.py",
                 "-v",
@@ -76,6 +81,7 @@
             "module": "pytest",
             "console": "integratedTerminal",
             "justMyCode": false,
+            "cwd": "${workspaceFolder}",
             "args": [
                 "-v",
                 "--no-header"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
             "request": "launch",
             "module": "instapaper_scraper.cli",
             "console": "integratedTerminal",
-            "justMyCode": false,
+            "justMyCode": true,
             "cwd": "${workspaceFolder}",
             "env": {
                 "PYTHONPATH": "${workspaceFolder}/src"
@@ -19,7 +19,7 @@
             "request": "launch",
             "module": "instapaper_scraper.cli",
             "console": "integratedTerminal",
-            "justMyCode": false,
+            "justMyCode": true,
             "cwd": "${workspaceFolder}",
             "args": ["--version"],
             "env": {
@@ -62,7 +62,7 @@
             "request": "launch",
             "module": "pytest",
             "console": "integratedTerminal",
-            "justMyCode": false,
+            "justMyCode": true,
             "cwd": "${workspaceFolder}",
             "args": [
                 "tests/test_cli.py",
@@ -80,7 +80,7 @@
             "request": "launch",
             "module": "pytest",
             "console": "integratedTerminal",
-            "justMyCode": false,
+            "justMyCode": true,
             "cwd": "${workspaceFolder}",
             "args": [
                 "-v",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug CLI",
+            "name": "Debug CLI", // Set a breakpoint in src/instapaper_scraper/api.py before launching
             "type": "debugpy",
             "request": "launch",
             "module": "instapaper_scraper.cli",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,7 +28,7 @@
             "name": "Debug API",
             "type": "debugpy",
             "request": "launch",
-            "program": "${workspaceFolder}/.vscode/debug_api.py",
+            "program": "${workspaceFolder}/scripts/debug_api.py",
             "console": "integratedTerminal",
             "justMyCode": false,
             "env": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,88 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug CLI",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "instapaper_scraper.cli",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}/src"
+            }
+        },
+        {
+            "name": "Debug CLI (--version)",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "instapaper_scraper.cli",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "args": ["--version"],
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}/src"
+            }
+        },
+        {
+            "name": "Debug API",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/.vscode/debug_api.py",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}/src"
+            }
+        },
+        {
+            "name": "Debug API Tests",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "args": [
+                "tests/test_api.py",
+                "-v",
+                "--no-header",
+                "--no-cov"
+            ],
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}/src"
+            }
+        },
+        {
+            "name": "Debug CLI Tests",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "args": [
+                "tests/test_cli.py",
+                "-v",
+                "--no-header",
+                "--no-cov"
+            ],
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}/src"
+            }
+        },
+        {
+            "name": "Debug All Tests",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "args": [
+                "-v",
+                "--no-header"
+            ],
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}/src"
+            }
+        }
+    ]
+}

--- a/scripts/debug_api.py
+++ b/scripts/debug_api.py
@@ -12,6 +12,7 @@ To debug a specific method:
   2. Select "Debug API" from the VS Code Run panel and press F5.
   3. Step through the mocked call flow.
 """
+
 import requests
 import requests_mock
 
@@ -76,9 +77,7 @@ def main() -> None:
         m.get(INSTAPAPER_USER_SESSION_URL, json=mock_session_response)
         m.get(INSTAPAPER_BOOKMARKS_URL, json=mock_bookmarks_response)
 
-        articles, has_more = client.get_articles(
-            page=1, add_article_preview=True
-        )
+        articles, has_more = client.get_articles(page=1, add_article_preview=True)
 
         print(f"Fetched {len(articles)} articles. has_more: {has_more}")
         print()

--- a/scripts/debug_api.py
+++ b/scripts/debug_api.py
@@ -50,20 +50,20 @@ def main() -> None:
         "bookmarks": [
             {
                 "id": 1,
-                "url": "http://example.com/1",
+                "url": "https://example.com/1",
                 "title": "Debug Article 1",
                 "description": "A preview of article 1.",
                 "author": "Author 1",
-                "time": 1785482560,
+                "time": 1785482560,  # ~2026-07-30 — a recent-ish bookmark for realistic mock data`
                 "site_name": "Example",
                 "liked": False,
                 "is_archived": False,
                 "tags": ["tag1"],
                 "notes": [],
             },
-            {
+            {  # Intentionally sparse — tests _parse_bookmarks handling of missing optional fields
                 "id": 2,
-                "url": "http://example.com/2",
+                "url": "https://example.com/2",
                 "title": "Debug Article 2",
                 "description": "",
             },
@@ -77,7 +77,11 @@ def main() -> None:
         m.get(INSTAPAPER_USER_SESSION_URL, json=mock_session_response)
         m.get(INSTAPAPER_BOOKMARKS_URL, json=mock_bookmarks_response)
 
-        articles, has_more = client.get_articles(page=1, add_article_preview=True)
+        try:
+            articles, has_more = client.get_articles(page=1, add_article_preview=True)
+        except Exception as exc:
+            print(f"[ERROR] get_articles raised: {exc!r}")
+            raise
 
         print(f"Fetched {len(articles)} articles. has_more: {has_more}")
         print()


### PR DESCRIPTION
Add launch configurations for debugging CLI and API, along with a debug helper script that mocks Instapaper API responses for testing client methods without real credentials.