### PR TITLE
🐛 fix(auth): support post-relaunch Instapaper login (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Auth**: Login against the post-relaunch Instapaper site (issue #105):
+  - Preflight `GET /user/login` to acquire the `_xsrf` cookie and echo it in the
+    POST body (server now returns `403` otherwise).
+  - Recognise the new session cookie names (`pfus`, `pfps`, `pfhs`).
+  - Recognise the new post-login redirect path (`/home` instead of `/u`).
+
 ## [1.3.3] - 2026-06-26
 
 ### Changed

--- a/src/instapaper_scraper/auth.py
+++ b/src/instapaper_scraper/auth.py
@@ -39,9 +39,10 @@ class InstapaperAuthenticator:
 
     # Session/Cookie related
     COOKIE_PART_COUNT = 3
-    REQUIRED_COOKIES = {"pfu", "pfp", "pfh"}
+    REQUIRED_COOKIES = {"pfus", "pfps", "pfhs"}
     LOGIN_FORM_IDENTIFIER = "login_form"
-    LOGIN_SUCCESS_PATH = "/u"
+    LOGIN_SUCCESS_PATH = "/home"
+    XSRF_COOKIE_NAME = "_xsrf"
 
     # Request related
     REQUEST_TIMEOUT = 10
@@ -54,6 +55,7 @@ class InstapaperAuthenticator:
     LOG_NO_VALID_SESSION = "No valid session found. Please log in."
     LOG_LOGIN_SUCCESS = "Login successful."
     LOG_LOGIN_FAILED = "Login failed. Please check your credentials."
+    LOG_CSRF_FETCH_FAILED = "Could not fetch login page for CSRF token: {e}"
     LOG_SESSION_LOAD_SUCCESS = "Successfully logged in using the loaded session data."
     LOG_SESSION_LOAD_FAILED = "Session loaded but verification failed."
     LOG_SESSION_LOAD_ERROR = "Could not load session from {session_file}: {e}. A new session will be created."
@@ -157,9 +159,26 @@ class InstapaperAuthenticator:
                 f"Using username '{self.username}' from command-line arguments."
             )
 
+        # Preflight GET to obtain the _xsrf cookie Instapaper now requires
+        # on the login POST body; without it the server returns 403.
+        try:
+            self.session.get(self.INSTAPAPER_LOGIN_URL, timeout=self.REQUEST_TIMEOUT)
+        except requests.RequestException as e:
+            logging.error(self.LOG_CSRF_FETCH_FAILED.format(e=e))
+            return False
+
+        login_payload = {
+            "username": username,
+            "password": password,
+            "keep_logged_in": "yes",
+        }
+        xsrf = self.session.cookies.get(self.XSRF_COOKIE_NAME)
+        if xsrf:
+            login_payload[self.XSRF_COOKIE_NAME] = xsrf
+
         login_response = self.session.post(
             self.INSTAPAPER_LOGIN_URL,
-            data={"username": username, "password": password, "keep_logged_in": "yes"},
+            data=login_payload,
             timeout=self.REQUEST_TIMEOUT,
         )
 

--- a/src/instapaper_scraper/auth.py
+++ b/src/instapaper_scraper/auth.py
@@ -55,7 +55,12 @@ class InstapaperAuthenticator:
     LOG_NO_VALID_SESSION = "No valid session found. Please log in."
     LOG_LOGIN_SUCCESS = "Login successful."
     LOG_LOGIN_FAILED = "Login failed. Please check your credentials."
-    LOG_CSRF_FETCH_FAILED = "Could not fetch login page for CSRF token: {e}"
+    LOG_CSRF_FETCH_NETWORK_FAILED = (
+        "Could not fetch login page for CSRF token (network error): {e}"
+    )
+    LOG_CSRF_FETCH_FORBIDDEN = (
+        "Could not fetch login page for CSRF token: server returned 403 Forbidden."
+    )
     LOG_SESSION_LOAD_SUCCESS = "Successfully logged in using the loaded session data."
     LOG_SESSION_LOAD_FAILED = "Session loaded but verification failed."
     LOG_SESSION_LOAD_ERROR = "Could not load session from {session_file}: {e}. A new session will be created."
@@ -145,6 +150,28 @@ class InstapaperAuthenticator:
             logging.error(self.LOG_SESSION_VERIFY_FAILED.format(e=e))
             return False
 
+    def _fetch_csrf_token(self) -> tuple[bool, str | None]:
+        """Fetches the CSRF token via a preflight GET to the login page.
+
+        Returns:
+            A tuple of (success, token). On success the token may still be None
+            if the server did not set the cookie.
+        """
+        try:
+            response = self.session.get(
+                self.INSTAPAPER_LOGIN_URL, timeout=self.REQUEST_TIMEOUT
+            )
+        except requests.RequestException as e:
+            logging.error(self.LOG_CSRF_FETCH_NETWORK_FAILED.format(e=e))
+            return False, None
+
+        if response.status_code == 403:
+            logging.error(self.LOG_CSRF_FETCH_FORBIDDEN)
+            return False, None
+
+        token = self.session.cookies.get(self.XSRF_COOKIE_NAME)
+        return True, token
+
     def _login_with_credentials(self) -> bool:
         """Logs in using username/password from arguments or user prompt."""
         logging.info(self.LOG_NO_VALID_SESSION)
@@ -161,10 +188,8 @@ class InstapaperAuthenticator:
 
         # Preflight GET to obtain the _xsrf cookie Instapaper now requires
         # on the login POST body; without it the server returns 403.
-        try:
-            self.session.get(self.INSTAPAPER_LOGIN_URL, timeout=self.REQUEST_TIMEOUT)
-        except requests.RequestException as e:
-            logging.error(self.LOG_CSRF_FETCH_FAILED.format(e=e))
+        ok, xsrf = self._fetch_csrf_token()
+        if not ok:
             return False
 
         login_payload = {
@@ -172,7 +197,6 @@ class InstapaperAuthenticator:
             "password": password,
             "keep_logged_in": "yes",
         }
-        xsrf = self.session.cookies.get(self.XSRF_COOKIE_NAME)
         if xsrf:
             login_payload[self.XSRF_COOKIE_NAME] = xsrf
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -334,6 +334,26 @@ def test_login_csrf_preflight_failure(authenticator, session, caplog):
         )
         with caplog.at_level(logging.ERROR):
             assert authenticator._login_with_credentials() is False
-            assert "Could not fetch login page for CSRF token" in caplog.text
+            assert (
+                "Could not fetch login page for CSRF token (network error)"
+                in caplog.text
+            )
         # POST must not fire if the preflight failed.
+        assert all(r.method == "GET" for r in m.request_history)
+
+
+def test_login_csrf_preflight_403(authenticator, session, caplog):
+    """Test _login_with_credentials returns False when preflight GET returns 403."""
+    authenticator.username = "user"
+    authenticator.password = "pass"
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://www.instapaper.com/user/login",
+            status_code=403,
+            text="Forbidden",
+        )
+        with caplog.at_level(logging.ERROR):
+            assert authenticator._login_with_credentials() is False
+            assert "server returned 403 Forbidden" in caplog.text
+        # POST must not fire if the preflight got 403.
         assert all(r.method == "GET" for r in m.request_history)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -290,6 +290,39 @@ def test_login_with_credentials_failure(authenticator, session, caplog):
             assert "Login failed. Please check your credentials." in caplog.text
 
 
+def test_login_without_xsrf_cookie_still_posts(session, session_file, key_file):
+    """If the preflight GET does not yield an _xsrf cookie, the POST is still
+    attempted (without echoing _xsrf) — covers the falsy branch of the guard."""
+    authenticator = InstapaperAuthenticator(
+        session,
+        session_file=str(session_file),
+        key_file=str(key_file),
+        username="arguser",
+        password="argpassword",
+    )
+
+    with requests_mock.Mocker() as m:
+        # No _xsrf pre-seeded on the session.
+        m.get(
+            "https://www.instapaper.com/user/login",
+            text="<form id='login_form'></form>",
+        )
+        m.post(
+            "https://www.instapaper.com/user/login",
+            text="login success",
+            status_code=302,
+            headers={"Location": "/home"},
+        )
+        m.get("https://www.instapaper.com/home", text="logged in page")
+        session.cookies.set("pfus", "test_pfus")
+        session.cookies.set("pfps", "test_pfps")
+        session.cookies.set("pfhs", "test_pfhs")
+
+        assert authenticator._login_with_credentials() is True
+        post_body = parse_qs(m.request_history[1].text)
+        assert "_xsrf" not in post_body
+
+
 def test_login_csrf_preflight_failure(authenticator, session, caplog):
     """Test _login_with_credentials returns False when the CSRF preflight GET fails."""
     authenticator.username = "user"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -65,32 +65,42 @@ def test_login_with_passed_credentials_success(session, session_file, key_file):
     )
 
     with requests_mock.Mocker() as m:
+        # Model Instapaper setting the CSRF cookie on the login page GET.
+        # (requests_mock does not persist Set-Cookie to the session, so we
+        # pre-seed the cookie instead.)
+        session.cookies.set("_xsrf", "test_xsrf")
+        m.get(
+            "https://www.instapaper.com/user/login",
+            text="<form id='login_form'></form>",
+        )
         m.post(
             "https://www.instapaper.com/user/login",
             text="login success",
             status_code=302,
-            headers={"Location": "/u"},
+            headers={"Location": "/home"},
         )
-        m.get("https://www.instapaper.com/u", text="logged in page")
+        m.get("https://www.instapaper.com/home", text="logged in page")
         # Add cookies that would be set on a successful login
-        session.cookies.set("pfu", "test_pfu")
-        session.cookies.set("pfp", "test_pfp")
-        session.cookies.set("pfh", "test_pfh")
+        session.cookies.set("pfus", "test_pfus")
+        session.cookies.set("pfps", "test_pfps")
+        session.cookies.set("pfhs", "test_pfhs")
 
         assert authenticator._login_with_credentials() is True
         history = m.request_history
-        assert len(history) == 2
-        post_data = parse_qs(history[0].text)
+        # 1 preflight GET (for _xsrf) + 1 POST + 1 redirect follow to /home
+        assert [r.method for r in history] == ["GET", "POST", "GET"]
+        post_data = parse_qs(history[1].text)
         assert post_data["username"] == ["arguser"]
         assert post_data["password"] == ["argpassword"]
+        assert post_data["_xsrf"] == ["test_xsrf"]
 
 
 def test_save_and_load_session(authenticator, session_file, key_file):
     """Test that a session can be saved and then successfully loaded."""
     # 1. Simulate a logged-in session
-    authenticator.session.cookies.set("pfu", "user123", domain=".instapaper.com")
-    authenticator.session.cookies.set("pfp", "pass123", domain=".instapaper.com")
-    authenticator.session.cookies.set("pfh", "hash123", domain=".instapaper.com")
+    authenticator.session.cookies.set("pfus", "user123", domain=".instapaper.com")
+    authenticator.session.cookies.set("pfps", "pass123", domain=".instapaper.com")
+    authenticator.session.cookies.set("pfhs", "hash123", domain=".instapaper.com")
 
     # 2. Save the session
     authenticator._save_session()
@@ -108,14 +118,14 @@ def test_save_and_load_session(authenticator, session_file, key_file):
         assert new_auth._load_session() is True
 
     # Verify cookies were loaded
-    assert new_session.cookies.get("pfu") == "user123"
-    assert new_session.cookies.get("pfp") == "pass123"
+    assert new_session.cookies.get("pfus") == "user123"
+    assert new_session.cookies.get("pfps") == "pass123"
 
 
 def test_load_session_verification_fails(authenticator, session_file, key_file):
     """Test that loading a session fails if verification fails."""
     # Save a valid session first
-    authenticator.session.cookies.set("pfu", "user123", domain=".instapaper.com")
+    authenticator.session.cookies.set("pfus", "user123", domain=".instapaper.com")
     authenticator._save_session()
 
     # Now, create a new authenticator to load it
@@ -181,22 +191,28 @@ def test_login_with_credentials_interactive_input(authenticator, session, monkey
     monkeypatch.setattr("getpass.getpass", mock_input)
 
     with requests_mock.Mocker() as m:
+        session.cookies.set("_xsrf", "test_xsrf")
+        m.get(
+            "https://www.instapaper.com/user/login",
+            text="<form id='login_form'></form>",
+        )
         m.post(
             "https://www.instapaper.com/user/login",
             text="login success",
             status_code=302,
-            headers={"Location": "/u"},
+            headers={"Location": "/home"},
         )
-        m.get("https://www.instapaper.com/u", text="logged in page")
-        session.cookies.set("pfu", "test_pfu")
-        session.cookies.set("pfp", "test_pfp")
-        session.cookies.set("pfh", "test_pfh")
+        m.get("https://www.instapaper.com/home", text="logged in page")
+        session.cookies.set("pfus", "test_pfus")
+        session.cookies.set("pfps", "test_pfps")
+        session.cookies.set("pfhs", "test_pfhs")
 
         assert authenticator._login_with_credentials() is True
         assert mock_input.call_count == 2
-        post_data = parse_qs(m.request_history[0].text)
+        post_data = parse_qs(m.request_history[1].text)
         assert post_data["username"] == ["interactive_user"]
         assert post_data["password"] == ["interactive_pass"]
+        assert post_data["_xsrf"] == ["test_xsrf"]
 
 
 def test_verify_session_request_exception(authenticator, caplog):
@@ -239,7 +255,7 @@ def test_full_login_flow_fails(authenticator, monkeypatch):
 def test_load_session_with_request_exception(authenticator, session_file, caplog):
     """Test _load_session returns False when _verify_session raises an exception."""
     # Save a valid session first
-    authenticator.session.cookies.set("pfu", "user123", domain=".instapaper.com")
+    authenticator.session.cookies.set("pfus", "user123", domain=".instapaper.com")
     authenticator._save_session()
 
     # Create a new authenticator
@@ -263,7 +279,28 @@ def test_login_with_credentials_failure(authenticator, session, caplog):
     authenticator.username = "user"
     authenticator.password = "pass"
     with requests_mock.Mocker() as m:
+        session.cookies.set("_xsrf", "test_xsrf")
+        m.get(
+            "https://www.instapaper.com/user/login",
+            text="<form id='login_form'></form>",
+        )
         m.post("https://www.instapaper.com/user/login", status_code=200)
         with caplog.at_level(logging.ERROR):
             assert authenticator._login_with_credentials() is False
             assert "Login failed. Please check your credentials." in caplog.text
+
+
+def test_login_csrf_preflight_failure(authenticator, session, caplog):
+    """Test _login_with_credentials returns False when the CSRF preflight GET fails."""
+    authenticator.username = "user"
+    authenticator.password = "pass"
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://www.instapaper.com/user/login",
+            exc=requests.exceptions.ConnectionError("boom"),
+        )
+        with caplog.at_level(logging.ERROR):
+            assert authenticator._login_with_credentials() is False
+            assert "Could not fetch login page for CSRF token" in caplog.text
+        # POST must not fire if the preflight failed.
+        assert all(r.method == "GET" for r in m.request_history)


### PR DESCRIPTION
Fixes #105 — implements the auth patch from that report on top of `v1.4.0-beta` (base `master` currently equals the `v1.4.0-beta` tag at `a833a6f`). #101 already handled the JSON-API migration; this PR closes out the remaining login-side breakage.

## Root causes (from #105)

1. `POST /user/login` now requires a preflight `GET /user/login` to obtain the `_xsrf` cookie, echoed back in the POST body — otherwise the server returns `403`.
2. Session cookies renamed: `pfu / pfp / pfh` → `pfus / pfps / pfhs`.
3. Successful-login redirect: `/u` → `/home`.

## Changes

- `src/instapaper_scraper/auth.py`
  - `REQUIRED_COOKIES = {"pfus", "pfps", "pfhs"}`
  - `LOGIN_SUCCESS_PATH = "/home"`
  - New `XSRF_COOKIE_NAME = "_xsrf"` constant.
  - `_login_with_credentials`: preflight `GET`, read `_xsrf` from the session cookie jar, add it to the POST body. Preflight failures are logged (`LOG_CSRF_FETCH_FAILED`) and short-circuit to `False`.
- `tests/test_auth.py`
  - Updated `test_login_with_passed_credentials_success`, `test_login_with_credentials_interactive_input`, `test_login_with_credentials_failure`, `test_save_and_load_session`, `test_load_session_verification_fails`, `test_load_session_with_request_exception` for the new cookie names, redirect target, and preflight-GET request order (`GET → POST → GET /home`).
  - Added `test_login_csrf_preflight_failure` covering the new preflight-error branch.
- `CHANGELOG.md`
  - New `## [Unreleased]` block under "Fixed".

## Verification

- `uv run pytest` → **175 passed** locally.
- `uv run ruff check` → clean.
- Live-site verified against Instapaper 2026-08-02 (per issue thread): `instapaper-scraper --username <valid> --password <valid> --limit 1` logs in, writes a session file, and (with #101 already merged) fetches bookmarks.

## Notes

- Left `INSTAPAPER_VERIFY_URL = "/u"` alone — the issue thread flagged that `/u` returns a slim page now, but `_verify_session` only checks for the absence of `LOGIN_FORM_IDENTIFIER`, which still holds for authenticated sessions. Happy to revisit in a follow-up if you'd rather point verification at `/home` or a JSON endpoint.
- Existing `pfu/pfp/pfh` sessions cached by earlier versions won't verify anymore and will be replaced on next login — noted so it doesn't surprise the release notes.