### PR TITLE
⬆️ chore(ci): upgrade pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.4
+    rev: v0.16.1
     hooks:
     -   id: ruff
         args: [--fix]
     -   id: ruff-format
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v2.3.0
     hooks:
     -   id: mypy
         files: ^src/


### PR DESCRIPTION
This PR upgrades all three pre-commit hooks to their latest stable versions.

### Changes

| Hook | From | To |
|------|------|-----|
| `pre-commit-hooks` | v4.6.0 | v6.0.0 |
| `ruff-pre-commit` | v0.4.4 | v0.16.1 |
| `mirrors-mypy` | v1.10.0 | v2.3.0 |

### Verification
- [x] `pre-commit run --all-files` passes with all upgraded hooks
- [x] No Ruff deprecation warnings on the configured rule codes
- [x] `check-yaml` passes on all YAML files
- [x] All upgraded versions fall within the dev-dependency ranges in `pyproject.toml`